### PR TITLE
[Draft] Adding Held Item Support for Raid Bosses

### DIFF
--- a/common/src/main/java/com/necro/raid/dens/common/raids/RaidBoss.java
+++ b/common/src/main/java/com/necro/raid/dens/common/raids/RaidBoss.java
@@ -178,6 +178,8 @@ public class RaidBoss {
         properties.setMinPerfectIVs(tierConfig.ivs());
         properties.setLevel(tierConfig.rewardLevel());
 
+        if (properties.getHeldItem() != null) properties.setHeldItem(null);
+
         Pokemon pokemon = new Pokemon();
         properties.apply(pokemon);
         pokemon.initialize();
@@ -493,8 +495,9 @@ public class RaidBoss {
             Codec.STRING.optionalFieldOf("ability", "").forGetter(PokemonProperties::getAbility),
             Codec.STRING.optionalFieldOf("nature", "").forGetter(PokemonProperties::getNature),
             Codec.INT.optionalFieldOf("level", -1).forGetter(PokemonProperties::getLevel),
-            Codec.STRING.listOf().optionalFieldOf("moves", new ArrayList<>()).forGetter(PokemonProperties::getMoves)
-            ).apply(inst, (species, gender, ability, nature, level, moves) -> {
+            Codec.STRING.listOf().optionalFieldOf("moves", new ArrayList<>()).forGetter(PokemonProperties::getMoves),
+            Codec.STRING.optionalFieldOf("heldItem", "").forGetter(PokemonProperties::getHeldItem)
+            ).apply(inst, (species, gender, ability, nature, level, moves, heldItem) -> {
                 PokemonProperties properties = PokemonProperties.Companion.parse("");
                 properties.setSpecies(species);
                 try { if (!gender.isBlank()) properties.setGender(Gender.valueOf(gender)); }
@@ -503,6 +506,7 @@ public class RaidBoss {
                 if (!nature.isBlank()) properties.setNature(nature);
                 if (level > 0) properties.setLevel(level);
                 if (!moves.isEmpty()) properties.setMoves(moves);
+                if (!heldItem.isEmpty()) properties.setHeldItem(heldItem);
                 return properties;
             })
         );

--- a/common/src/main/java/com/necro/raid/dens/common/raids/RaidBossAdditions.java
+++ b/common/src/main/java/com/necro/raid/dens/common/raids/RaidBossAdditions.java
@@ -80,6 +80,7 @@ public class RaidBossAdditions {
                 if (properties.getNature() != null) boss.getProperties().setNature(properties.getNature());
                 if (properties.getLevel() != null) boss.getProperties().setLevel(properties.getLevel());
                 if (properties.getMoves() != null) boss.getProperties().setMoves(properties.getMoves());
+                if (properties.getHeldItem() != null) boss.getProperties().setHeldItem(properties.getHeldItem());
                 if (properties.getTeraType() != null) boss.getProperties().setTeraType(properties.getTeraType());
             }
 
@@ -224,6 +225,10 @@ public class RaidBossAdditions {
         return Optional.ofNullable(properties.getMoves());
     }
 
+    private static Optional<String> heldItem(PokemonProperties properties) {
+        return Optional.ofNullable(properties.getHeldItem());
+    }
+
     private static Codec<PokemonProperties> propertiesCodec() {
         return RecordCodecBuilder.create(inst -> inst.group(
                 Codec.STRING.optionalFieldOf("species").forGetter(RaidBossAdditions::species),
@@ -231,8 +236,9 @@ public class RaidBossAdditions {
                 Codec.STRING.optionalFieldOf("ability").forGetter(RaidBossAdditions::ability),
                 Codec.STRING.optionalFieldOf("nature").forGetter(RaidBossAdditions::nature),
                 Codec.INT.optionalFieldOf("level").forGetter(RaidBossAdditions::level),
-                Codec.STRING.listOf().optionalFieldOf("moves").forGetter(RaidBossAdditions::moves)
-            ).apply(inst, (species, gender, ability, nature, level, moves) -> {
+                Codec.STRING.listOf().optionalFieldOf("moves").forGetter(RaidBossAdditions::moves),
+                Codec.STRING.optionalFieldOf("heldItem").forGetter(RaidBossAdditions::heldItem)
+                ).apply(inst, (species, gender, ability, nature, level, moves, heldItem) -> {
                 PokemonProperties properties = new PokemonProperties();
                 species.ifPresent(properties::setSpecies);
                 try {
@@ -243,6 +249,7 @@ public class RaidBossAdditions {
                 nature.ifPresent(properties::setNature);
                 level.ifPresent(properties::setLevel);
                 moves.ifPresent(properties::setMoves);
+                heldItem.ifPresent(properties::setHeldItem);
                 return properties;
             })
         );


### PR DESCRIPTION
Adds held item support for raid boss.

Can be specified in the JSON like so:

```
"pokemon": {
        "species": "scyther",
    "heldItem": "cobblemon:leftovers",
. . .
```

Held item is intentionally not present in reward pokemon. 

<img width="442" height="347" alt="NoItem" src="https://github.com/user-attachments/assets/dc3db4cc-fff0-4417-b23f-43377896b4ee" />



Draft because I need some help understanding how the synchronization works in this mod, held item likely isn't synchronized for other players if one player uses knockoff:


<img width="1310" height="669" alt="knockedOffItem" src="https://github.com/user-attachments/assets/75c42cb3-6cfa-493c-8272-848ef606ab44" />



