### PR TITLE
fix: prevent RaidHelper NPE during worldgen

### DIFF
--- a/common/src/main/java/com/necro/raid/dens/common/raids/helpers/RaidHelper.java
+++ b/common/src/main/java/com/necro/raid/dens/common/raids/helpers/RaidHelper.java
@@ -20,6 +20,7 @@ import java.util.*;
 
 public class RaidHelper extends SavedData {
     public static RaidHelper INSTANCE;
+    private static final RaidResetContext INITIAL_GLOBAL_RESET = new RaidResetContext(0, 0, 0);
 
     public static final Map<UUID, RaidInstance> ACTIVE_RAIDS = new HashMap<>();
     public static final Map<UUID, RequestHandler> REQUEST_QUEUE = new HashMap<>();
@@ -96,7 +97,7 @@ public class RaidHelper extends SavedData {
     }
 
     public static RaidResetContext getGlobalCycle() {
-        return INSTANCE.GLOBAL_RESET;
+        return INSTANCE == null ? INITIAL_GLOBAL_RESET : INSTANCE.GLOBAL_RESET;
     }
 
     public static void setGlobalCycle(long gameTime) {


### PR DESCRIPTION
## Summary

Fixes a server startup crash that could happen while raid den features are being placed during world generation.

## Problem

The server crashed with a `NullPointerException` during feature placement:

`Cannot read field "GLOBAL_RESET" because "RaidHelper.INSTANCE" is null`

The crash path was:

`RaidDenFeature.place` -> `RaidCrystalBlockEntity.setRaidBoss` -> `RaidResetContext` -> `RaidHelper.getGlobalCycle`

At that point in startup, raid den worldgen can run before `RaidHelper` has loaded its saved data, so `RaidHelper.INSTANCE` may still be `null`.

## Fix

`RaidHelper.getGlobalCycle()` now returns an initial safe reset context when `RaidHelper.INSTANCE` has not been initialized yet.

This prevents raid den generation from crashing during early server startup while preserving the saved global reset state once `RaidHelper` is loaded.