### PR TITLE
add github workflow for building mods.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
+    - name: Make gradlew executable
+      uses: chmod +x ./gradlew
+    
     - name: Build Fabric
       run: ./gradlew fabric:build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.0
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5.3.0
       with:
         java-version: '21'
         distribution: 'corretto'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build Mod
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'corretto'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build Fabric
+      run: ./gradlew fabric:build
+
+    - name: Build Neoforge
+      run: ./gradlew neoforge:build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,7 @@
 name: Build Mod
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: [push, pull_request]
+  
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
     - name: Make gradlew executable
-      uses: chmod +x ./gradlew
+      run: chmod +x ./gradlew
     
     - name: Build Fabric
       run: ./gradlew fabric:build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
-    - name: Make gradlew executable
+    - name: Make gradlew Executable
       run: chmod +x ./gradlew
     
     - name: Build Fabric
@@ -29,3 +29,12 @@ jobs:
 
     - name: Build Neoforge
       run: ./gradlew neoforge:build
+    
+    - name: Prepare Upload Artifact
+      run: mkdir -p ./artifact/fabric && mkdir -p ./artifact/neoforge && mv ./fabric/build/libs/* ./artifact/fabric && mv ./neoforge/build/libs/* ./artifact/neoforge
+
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        name: build-output
+        path: ./artifact


### PR DESCRIPTION
# What is this?
This pull requests will allow you to automatically test your mod after you push, or when someone makes a pull request to your repo by building it.

# Why?
When changes are made to this repo, or a contributor creates a pull request, you can easily tell if the mod will build with just a press of a button. and you can download the built mods from GitHub, and test it on a client, without going into a code editor or terminal on your computer ( you still have to test the mod on your computer ).

# Read before merging! Very Important!
Think twice before you merge this. I am only making this pull request just because I made this just to test one of my pull requests to this mod. 
This feature is very convenient, but only with good habits.
By downloading the artifacts from GitHub, you are essentially trusting GitHub will not tamper your builds. 
Before downloading an artifact from a pull request from another contributor, please make sure that certain contributor did not ship malicious stuff in his code, you can check in the pull requests file changes.

Also, please go to https://github.com/necro50n3/cobblemon-raiddens/settings/actions
and make sure `Approval for running fork pull request workflows from contributors` is set to `Require approval for all external contributors`, if you decide to merge this feature.
This is because you cannot trust any contributors (including me :smile:)
It is a good practice to check the pull request changes before allowing contributors to run workflows on your repo.
<img width="844" height="443" alt="image" src="https://github.com/user-attachments/assets/628e6c60-332b-41f4-a3ad-8970ea47d82e" />